### PR TITLE
Partition the table based on the 'EdgeStartTimestamp' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=4.3.2"
   },
   "dependencies": {
-    "@google-cloud/bigquery": "0.9.6",
+    "@google-cloud/bigquery": "1.3.0",
     "@google-cloud/storage": "1.2.1",
     "node-fetch": "^2.1.2"
   },


### PR DESCRIPTION
So our logs table gets quite big, which can be costly when there aren't any partitions setup.  I haven't tested this yet, but it should make the table partitioned by time, so seeing short term trends is a little less costly.